### PR TITLE
Using Actions and Shortcuts to Replace `RawKeyboard.instance.addListener(_handleKeyEvent)`

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -42,14 +42,14 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -87,7 +87,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -108,7 +108,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -120,7 +120,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -155,20 +155,13 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.9"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,21 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -49,7 +42,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,21 +73,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   mongol:
     dependency: "direct main"
     description:
@@ -108,7 +101,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -120,7 +113,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -141,21 +134,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:

--- a/lib/src/base/mongol_paragraph.dart
+++ b/lib/src/base/mongol_paragraph.dart
@@ -120,17 +120,8 @@ class MongolLineMetrics {
   }
 
   @override
-  int get hashCode =>
-      hashValues(
-          hardBreak,
-          ascent,
-          descent,
-          unscaledAscent,
-          height,
-          width,
-          top,
-          baseline,
-          lineNumber);
+  int get hashCode => hashValues(hardBreak, ascent, descent, unscaledAscent,
+      height, width, top, baseline, lineNumber);
 
   @override
   String toString() {
@@ -163,11 +154,13 @@ class MongolParagraph {
   /// or extended directly.
   ///
   /// To create a [MongolParagraph] object, use a [MongolParagraphBuilder].
-  MongolParagraph._(this._runs,
-      this._text,
-      this._maxLines,
-      this._ellipsis,
-      this._textAlign,);
+  MongolParagraph._(
+    this._runs,
+    this._text,
+    this._maxLines,
+    this._ellipsis,
+    this._textAlign,
+  );
 
   final String _text;
   final List<_TextRun> _runs;
@@ -415,7 +408,7 @@ class MongolParagraph {
     // find the afinity
     final lineEndCharOffset = matchedRun.end;
     final textAfinity =
-    (textOffset == lineEndCharOffset) ? upstream : downstream;
+        (textOffset == lineEndCharOffset) ? upstream : downstream;
     return [textOffset, textAfinity];
   }
 
@@ -447,8 +440,8 @@ class MongolParagraph {
     canvas.restore();
   }
 
-  void _drawEachRunInCurrentLine(Canvas canvas, _LineInfo line,
-      bool shouldDrawEllipsis, bool isLastLine) {
+  void _drawEachRunInCurrentLine(
+      Canvas canvas, _LineInfo line, bool shouldDrawEllipsis, bool isLastLine) {
     canvas.save();
 
     var runSpacing = 0.0;
@@ -764,9 +757,7 @@ class MongolParagraph {
       double baseline = 0;
       for (int j = line.textRunStart; j < line.textRunEnd; j += 1) {
         final textRun = _runs[j];
-        final runMetrics = textRun.paragraph
-            .computeLineMetrics()
-            .first;
+        final runMetrics = textRun.paragraph.computeLineMetrics().first;
 
         // last textRun of this line
         if (j == line.textRunEnd - 1) {
@@ -781,6 +772,18 @@ class MongolParagraph {
         final previousLineAscent = previousMetrics?.ascent ?? 0.0;
         final previousLineBaseline = previousMetrics?.baseline ?? 0.0;
         baseline = previousLineBaseline + previousLineAscent + descent;
+      }
+
+      // ends with new line
+      if (line.textRunStart == -1 && line.textRunEnd == -1) {
+        final previousMetrics = metrics[index - 1];
+        hardBreak = true;
+        ascent = previousMetrics.ascent;
+        descent = previousMetrics.descent;
+        unscaledAscent = previousMetrics.unscaledAscent;
+        height = previousMetrics.height;
+        width = previousMetrics.width;
+        baseline = previousMetrics.baseline + previousMetrics.ascent + descent;
       }
 
       double top = 0;
@@ -848,13 +851,13 @@ class MongolParagraphConstraints {
 /// After constructing a [MongolParagraph], call [MongolParagraph.layout] on
 /// it and then paint it with [MongolParagraph.draw].
 class MongolParagraphBuilder {
-  MongolParagraphBuilder(ui.ParagraphStyle style, {
+  MongolParagraphBuilder(
+    ui.ParagraphStyle style, {
     MongolTextAlign textAlign = MongolTextAlign.top,
     double textScaleFactor = 1.0,
     int? maxLines,
     String? ellipsis,
-  })
-      : _paragraphStyle = style,
+  })  : _paragraphStyle = style,
         _textAlign = textAlign,
         _textScaleFactor = textScaleFactor,
         _maxLines = maxLines,
@@ -947,7 +950,7 @@ class MongolParagraphBuilder {
       final paragraph = builder.build();
       paragraph.layout(const ui.ParagraphConstraints(width: double.infinity));
       final run =
-      _TextRun(startIndex, endIndex, segment.isRotatable, paragraph);
+          _TextRun(startIndex, endIndex, segment.isRotatable, paragraph);
       runs.add(run);
       builder = null;
       startIndex = endIndex;

--- a/lib/src/base/mongol_text_painter.dart
+++ b/lib/src/base/mongol_text_painter.dart
@@ -664,13 +664,13 @@ class MongolTextPainter {
   }
 
   List<MongolLineMetrics>? _lineMetricsCache;
-  /// Returns the full list of [LineMetrics] that describe in detail the various
+  /// Returns the full list of [MongolLineMetrics] that describe in detail the various
   /// metrics of each laid out line.
   ///
-  /// The [LineMetrics] list is presented in the order of the lines they represent.
+  /// The [MongolLineMetrics] list is presented in the order of the lines they represent.
   /// For example, the first line is in the zeroth index.
   ///
-  /// [LineMetrics] contains measurements such as ascent, descent, baseline, and
+  /// [MongolLineMetrics] contains measurements such as ascent, descent, baseline, and
   /// width for the line as a whole, and may be useful for aligning additional
   /// widgets to a particular line.
   ///

--- a/lib/src/base/mongol_text_painter.dart
+++ b/lib/src/base/mongol_text_painter.dart
@@ -97,6 +97,7 @@ class MongolTextPainter {
   /// in framework will automatically invoke this method.
   void markNeedsLayout() {
     _paragraph = null;
+    _lineMetricsCache = null;
     _needsLayout = true;
     _previousCaretPosition = null;
     _previousCaretPrototype = null;
@@ -363,6 +364,7 @@ class MongolTextPainter {
     _lastMinHeight = minHeight;
     _lastMaxHeight = maxHeight;
     // A change in layout invalidates the cached caret metrics as well.
+    _lineMetricsCache = null;
     _previousCaretPosition = null;
     _previousCaretPrototype = null;
     _paragraph!.layout(MongolParagraphConstraints(height: maxHeight));
@@ -659,5 +661,22 @@ class MongolTextPainter {
   TextRange getLineBoundary(TextPosition position) {
     assert(!_needsLayout);
     return _paragraph!.getLineBoundary(position);
+  }
+
+  List<MongolLineMetrics>? _lineMetricsCache;
+  /// Returns the full list of [LineMetrics] that describe in detail the various
+  /// metrics of each laid out line.
+  ///
+  /// The [LineMetrics] list is presented in the order of the lines they represent.
+  /// For example, the first line is in the zeroth index.
+  ///
+  /// [LineMetrics] contains measurements such as ascent, descent, baseline, and
+  /// width for the line as a whole, and may be useful for aligning additional
+  /// widgets to a particular line.
+  ///
+  /// Valid only after [layout] has been called.
+  List<MongolLineMetrics> computeLineMetrics() {
+    assert(!_needsLayout);
+    return  _lineMetricsCache ??= _paragraph!.computeLineMetrics();
   }
 }

--- a/lib/src/editing/default_mongol_text_editing_shortcuts.dart
+++ b/lib/src/editing/default_mongol_text_editing_shortcuts.dart
@@ -1,0 +1,377 @@
+// Copyright 2014 The Flutter Authors.
+// Copyright 2021 Suragch.
+// All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// Swap up/down arrow keys and left/right arrow keys on platforms other than the web.
+/// [DefaultTextEditingShortcuts._webDisablingTextShortcuts] said, "Web handles
+/// its text selection natively and doesn't use any of these shortcuts in Flutter".
+/// so maybe there is no way to swap these keys, but I'm not sure.
+class DefaultMongolTextEditingShortcuts extends StatelessWidget {
+  const DefaultMongolTextEditingShortcuts({Key? key, required this.child})
+      : super(key: key);
+
+  final Widget child;
+
+  // These are shortcuts are shared between most platforms except macOS for it
+  // uses different modifier keys as the line/word modifier.
+  static final Map<ShortcutActivator, Intent> _commonShortcuts =
+      <ShortcutActivator, Intent>{
+    // Arrow: Move Selection.
+    const SingleActivator(LogicalKeyboardKey.arrowUp):
+        const ExtendSelectionByCharacterIntent(
+            forward: false, collapseSelection: true),
+    const SingleActivator(LogicalKeyboardKey.arrowDown):
+        const ExtendSelectionByCharacterIntent(
+            forward: true, collapseSelection: true),
+    const SingleActivator(LogicalKeyboardKey.arrowLeft):
+        const ExtendSelectionVerticallyToAdjacentLineIntent(
+            forward: false, collapseSelection: true),
+    const SingleActivator(LogicalKeyboardKey.arrowRight):
+        const ExtendSelectionVerticallyToAdjacentLineIntent(
+            forward: true, collapseSelection: true),
+
+    // Shift + Arrow: Extend Selection.
+    const SingleActivator(LogicalKeyboardKey.arrowUp, shift: true):
+        const ExtendSelectionByCharacterIntent(
+            forward: false, collapseSelection: false),
+    const SingleActivator(LogicalKeyboardKey.arrowDown, shift: true):
+        const ExtendSelectionByCharacterIntent(
+            forward: true, collapseSelection: false),
+    const SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true):
+        const ExtendSelectionVerticallyToAdjacentLineIntent(
+            forward: false, collapseSelection: false),
+    const SingleActivator(LogicalKeyboardKey.arrowRight, shift: true):
+        const ExtendSelectionVerticallyToAdjacentLineIntent(
+            forward: true, collapseSelection: false),
+
+    const SingleActivator(LogicalKeyboardKey.arrowUp, alt: true):
+        const ExtendSelectionToLineBreakIntent(
+            forward: false, collapseSelection: true),
+    const SingleActivator(LogicalKeyboardKey.arrowDown, alt: true):
+        const ExtendSelectionToLineBreakIntent(
+            forward: true, collapseSelection: true),
+    const SingleActivator(LogicalKeyboardKey.arrowLeft, alt: true):
+        const ExtendSelectionToDocumentBoundaryIntent(
+            forward: false, collapseSelection: true),
+    const SingleActivator(LogicalKeyboardKey.arrowRight, alt: true):
+        const ExtendSelectionToDocumentBoundaryIntent(
+            forward: true, collapseSelection: true),
+
+    const SingleActivator(LogicalKeyboardKey.arrowUp, shift: true, alt: true):
+        const ExtendSelectionToLineBreakIntent(
+            forward: false, collapseSelection: false),
+    const SingleActivator(LogicalKeyboardKey.arrowDown, shift: true, alt: true):
+        const ExtendSelectionToLineBreakIntent(
+            forward: true, collapseSelection: false),
+    const SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true, alt: true):
+        const ExtendSelectionToDocumentBoundaryIntent(
+            forward: false, collapseSelection: false),
+    const SingleActivator(LogicalKeyboardKey.arrowRight,
+            shift: true, alt: true):
+        const ExtendSelectionToDocumentBoundaryIntent(
+            forward: true, collapseSelection: false),
+
+    const SingleActivator(LogicalKeyboardKey.arrowUp, control: true):
+        const ExtendSelectionToNextWordBoundaryIntent(
+            forward: false, collapseSelection: true),
+    const SingleActivator(LogicalKeyboardKey.arrowDown, control: true):
+        const ExtendSelectionToNextWordBoundaryIntent(
+            forward: true, collapseSelection: true),
+
+    const SingleActivator(LogicalKeyboardKey.arrowUp,
+            shift: true, control: true):
+        const ExtendSelectionToNextWordBoundaryIntent(
+            forward: false, collapseSelection: false),
+    const SingleActivator(LogicalKeyboardKey.arrowDown,
+            shift: true, control: true):
+        const ExtendSelectionToNextWordBoundaryIntent(
+            forward: true, collapseSelection: false),
+  };
+
+  // The following key combinations have no effect on text editing on this
+  // platform:
+  //   * End
+  //   * Home
+  //   * Meta + X
+  //   * Meta + C
+  //   * Meta + V
+  //   * Meta + A
+  //   * Meta + shift? + Z
+  //   * Meta + shift? + arrow down
+  //   * Meta + shift? + arrow left
+  //   * Meta + shift? + arrow right
+  //   * Meta + shift? + arrow up
+  //   * Shift + end
+  //   * Shift + home
+  //   * Meta + shift? + delete
+  //   * Meta + shift? + backspace
+  static final Map<ShortcutActivator, Intent> _androidShortcuts =
+      _commonShortcuts;
+
+  static final Map<ShortcutActivator, Intent> _fuchsiaShortcuts =
+      _androidShortcuts;
+
+  static final Map<ShortcutActivator, Intent> _linuxShortcuts =
+      _commonShortcuts;
+
+  // macOS document shortcuts: https://support.apple.com/en-us/HT201236.
+  // The macOS shortcuts uses different word/line modifiers than most other
+  // platforms.
+  static final Map<ShortcutActivator, Intent> _macShortcuts =
+      <ShortcutActivator, Intent>{
+    const SingleActivator(LogicalKeyboardKey.arrowUp):
+        const ExtendSelectionByCharacterIntent(
+            forward: false, collapseSelection: true),
+    const SingleActivator(LogicalKeyboardKey.arrowDown):
+        const ExtendSelectionByCharacterIntent(
+            forward: true, collapseSelection: true),
+    const SingleActivator(LogicalKeyboardKey.arrowLeft):
+        const ExtendSelectionVerticallyToAdjacentLineIntent(
+            forward: false, collapseSelection: true),
+    const SingleActivator(LogicalKeyboardKey.arrowRight):
+        const ExtendSelectionVerticallyToAdjacentLineIntent(
+            forward: true, collapseSelection: true),
+
+    // Shift + Arrow: Extend Selection.
+    const SingleActivator(LogicalKeyboardKey.arrowUp, shift: true):
+        const ExtendSelectionByCharacterIntent(
+            forward: false, collapseSelection: false),
+    const SingleActivator(LogicalKeyboardKey.arrowDown, shift: true):
+        const ExtendSelectionByCharacterIntent(
+            forward: true, collapseSelection: false),
+    const SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true):
+        const ExtendSelectionVerticallyToAdjacentLineIntent(
+            forward: false, collapseSelection: false),
+    const SingleActivator(LogicalKeyboardKey.arrowRight, shift: true):
+        const ExtendSelectionVerticallyToAdjacentLineIntent(
+            forward: true, collapseSelection: false),
+
+    const SingleActivator(LogicalKeyboardKey.arrowUp, alt: true):
+        const ExtendSelectionToNextWordBoundaryIntent(
+            forward: false, collapseSelection: true),
+    const SingleActivator(LogicalKeyboardKey.arrowDown, alt: true):
+        const ExtendSelectionToNextWordBoundaryIntent(
+            forward: true, collapseSelection: true),
+    const SingleActivator(LogicalKeyboardKey.arrowLeft, alt: true):
+        const ExtendSelectionToLineBreakIntent(
+            forward: false, collapseSelection: true),
+    const SingleActivator(LogicalKeyboardKey.arrowRight, alt: true):
+        const ExtendSelectionToLineBreakIntent(
+            forward: true, collapseSelection: true),
+
+    const SingleActivator(LogicalKeyboardKey.arrowUp, shift: true, alt: true):
+        const ExtendSelectionToNextWordBoundaryOrCaretLocationIntent(
+            forward: false),
+    const SingleActivator(LogicalKeyboardKey.arrowDown, shift: true, alt: true):
+        const ExtendSelectionToNextWordBoundaryOrCaretLocationIntent(
+            forward: true),
+    const SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true, alt: true):
+        const ExtendSelectionToLineBreakIntent(
+            forward: false, collapseSelection: false, collapseAtReversal: true),
+    const SingleActivator(LogicalKeyboardKey.arrowRight,
+            shift: true, alt: true):
+        const ExtendSelectionToLineBreakIntent(
+            forward: true, collapseSelection: false, collapseAtReversal: true),
+
+    const SingleActivator(LogicalKeyboardKey.arrowUp, meta: true):
+        const ExtendSelectionToLineBreakIntent(
+            forward: false, collapseSelection: true),
+    const SingleActivator(LogicalKeyboardKey.arrowDown, meta: true):
+        const ExtendSelectionToLineBreakIntent(
+            forward: true, collapseSelection: true),
+    const SingleActivator(LogicalKeyboardKey.arrowLeft, meta: true):
+        const ExtendSelectionToDocumentBoundaryIntent(
+            forward: false, collapseSelection: true),
+    const SingleActivator(LogicalKeyboardKey.arrowRight, meta: true):
+        const ExtendSelectionToDocumentBoundaryIntent(
+            forward: true, collapseSelection: true),
+
+    const SingleActivator(LogicalKeyboardKey.arrowUp, shift: true, meta: true):
+        const ExpandSelectionToLineBreakIntent(forward: false),
+    const SingleActivator(LogicalKeyboardKey.arrowDown,
+        shift: true,
+        meta: true): const ExpandSelectionToLineBreakIntent(forward: true),
+    const SingleActivator(LogicalKeyboardKey.arrowLeft,
+            shift: true, meta: true):
+        const ExtendSelectionToDocumentBoundaryIntent(
+            forward: false, collapseSelection: false),
+    const SingleActivator(LogicalKeyboardKey.arrowRight,
+            shift: true, meta: true):
+        const ExtendSelectionToDocumentBoundaryIntent(
+            forward: true, collapseSelection: false),
+  };
+
+  // There is no complete documentation of iOS shortcuts. Use mac shortcuts for
+  // now.
+  static final Map<ShortcutActivator, Intent> _iOSShortcuts = _macShortcuts;
+
+  static final Map<ShortcutActivator, Intent> _windowsShortcuts =
+      _commonShortcuts;
+
+  static Map<ShortcutActivator, Intent> get _shortcuts {
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return _androidShortcuts;
+      case TargetPlatform.fuchsia:
+        return _fuchsiaShortcuts;
+      case TargetPlatform.iOS:
+        return _iOSShortcuts;
+      case TargetPlatform.linux:
+        return _linuxShortcuts;
+      case TargetPlatform.macOS:
+        return _macShortcuts;
+      case TargetPlatform.windows:
+        return _windowsShortcuts;
+    }
+  }
+
+  // Web handles its text selection natively and doesn't use any of these
+  // shortcuts in Flutter.
+  static final Map<ShortcutActivator, Intent> _webDisablingTextShortcuts =
+      <ShortcutActivator, Intent>{
+    for (final bool pressShift in const <bool>[
+      true,
+      false
+    ]) ...<SingleActivator, Intent>{
+      SingleActivator(LogicalKeyboardKey.backspace, shift: pressShift):
+          const DoNothingAndStopPropagationTextIntent(),
+      SingleActivator(LogicalKeyboardKey.delete, shift: pressShift):
+          const DoNothingAndStopPropagationTextIntent(),
+      SingleActivator(LogicalKeyboardKey.backspace,
+          alt: true,
+          shift: pressShift): const DoNothingAndStopPropagationTextIntent(),
+      SingleActivator(LogicalKeyboardKey.delete, alt: true, shift: pressShift):
+          const DoNothingAndStopPropagationTextIntent(),
+      SingleActivator(LogicalKeyboardKey.backspace,
+          control: true,
+          shift: pressShift): const DoNothingAndStopPropagationTextIntent(),
+      SingleActivator(LogicalKeyboardKey.delete,
+          control: true,
+          shift: pressShift): const DoNothingAndStopPropagationTextIntent(),
+      SingleActivator(LogicalKeyboardKey.backspace,
+          meta: true,
+          shift: pressShift): const DoNothingAndStopPropagationTextIntent(),
+      SingleActivator(LogicalKeyboardKey.delete, meta: true, shift: pressShift):
+          const DoNothingAndStopPropagationTextIntent(),
+    },
+    const SingleActivator(LogicalKeyboardKey.arrowDown, alt: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowLeft, alt: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowRight, alt: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowUp, alt: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowDown, shift: true, alt: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true, alt: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowRight,
+        shift: true, alt: true): const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowUp, shift: true, alt: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowDown):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowLeft):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowRight):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowUp):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowLeft, control: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowRight, control: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowLeft,
+        shift: true,
+        control: true): const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowRight,
+        shift: true,
+        control: true): const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.end):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.home):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowDown, meta: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowLeft, meta: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowRight, meta: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowUp, meta: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowDown,
+        shift: true, meta: true): const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowLeft,
+        shift: true, meta: true): const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowRight,
+        shift: true, meta: true): const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowUp, shift: true, meta: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowDown, shift: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowRight, shift: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowUp, shift: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.end, shift: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.home, shift: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.end, control: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.home, control: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.space):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.enter):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.keyX, control: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.keyX, meta: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.keyC, control: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.keyC, meta: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.keyV, control: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.keyV, meta: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.keyA, control: true):
+        const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.keyA, meta: true):
+        const DoNothingAndStopPropagationTextIntent(),
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    Widget result = child;
+    if (kIsWeb) {
+      // On the web, these shortcuts make sure of the following:
+      //
+      // 1. Shortcuts fired when an EditableText is focused are ignored and
+      //    forwarded to the browser by the EditableText's Actions, because it
+      //    maps DoNothingAndStopPropagationTextIntent to DoNothingAction.
+      // 2. Shortcuts fired when no EditableText is focused will still trigger
+      //    _shortcuts assuming DoNothingAndStopPropagationTextIntent is
+      //    unhandled elsewhere.
+      result = Shortcuts(
+          debugLabel: '<Web Disabling Text Editing Shortcuts>',
+          shortcuts: _webDisablingTextShortcuts,
+          child: result);
+    }
+    return Shortcuts(
+        debugLabel: '<Default Text Editing Shortcuts>',
+        shortcuts: _shortcuts,
+        child: result);
+  }
+}

--- a/lib/src/editing/mongol_editable_text.dart
+++ b/lib/src/editing/mongol_editable_text.dart
@@ -1357,7 +1357,7 @@ class MongolEditableTextState extends State<MongolEditableText>
 
     if (!_didAutoFocus && widget.autofocus) {
       _didAutoFocus = true;
-      SchedulerBinding.instance!.addPostFrameCallback((_) {
+      SchedulerBinding.instance.addPostFrameCallback((_) {
         if (mounted) {
           FocusScope.of(context).autofocus(widget.focusNode);
         }
@@ -1446,7 +1446,7 @@ class MongolEditableTextState extends State<MongolEditableText>
     _selectionOverlay = null;
     _focusAttachment!.detach();
     widget.focusNode.removeListener(_handleFocusChanged);
-    WidgetsBinding.instance!.removeObserver(this);
+    WidgetsBinding.instance.removeObserver(this);
     _clipboardStatus?.removeListener(_onChangedClipboardStatus);
     _clipboardStatus?.dispose();
     super.dispose();
@@ -1909,7 +1909,7 @@ class MongolEditableTextState extends State<MongolEditableText>
       return;
     }
     _showCaretOnScreenScheduled = true;
-    SchedulerBinding.instance!.addPostFrameCallback((Duration _) {
+    SchedulerBinding.instance.addPostFrameCallback((Duration _) {
       _showCaretOnScreenScheduled = false;
       if (_currentCaretRect == null || !_scrollController!.hasClients) {
         return;
@@ -1964,16 +1964,16 @@ class MongolEditableTextState extends State<MongolEditableText>
   @override
   void didChangeMetrics() {
     if (_lastBottomViewInset !=
-        WidgetsBinding.instance!.window.viewInsets.bottom) {
-      SchedulerBinding.instance!.addPostFrameCallback((Duration _) {
+        WidgetsBinding.instance.window.viewInsets.bottom) {
+      SchedulerBinding.instance.addPostFrameCallback((Duration _) {
         _selectionOverlay?.updateForScroll();
       });
       if (_lastBottomViewInset <
-          WidgetsBinding.instance!.window.viewInsets.bottom) {
+          WidgetsBinding.instance.window.viewInsets.bottom) {
         _scheduleShowCaretOnScreen();
       }
     }
-    _lastBottomViewInset = WidgetsBinding.instance!.window.viewInsets.bottom;
+    _lastBottomViewInset = WidgetsBinding.instance.window.viewInsets.bottom;
   }
 
   @pragma('vm:notify-debugger-on-exception')
@@ -2138,8 +2138,8 @@ class MongolEditableTextState extends State<MongolEditableText>
     _updateOrDisposeSelectionOverlayIfNeeded();
     if (_hasFocus) {
       // Listen for changing viewInsets, which indicates keyboard showing up.
-      WidgetsBinding.instance!.addObserver(this);
-      _lastBottomViewInset = WidgetsBinding.instance!.window.viewInsets.bottom;
+      WidgetsBinding.instance.addObserver(this);
+      _lastBottomViewInset = WidgetsBinding.instance.window.viewInsets.bottom;
       if (!widget.readOnly) {
         _scheduleShowCaretOnScreen();
       }
@@ -2149,7 +2149,7 @@ class MongolEditableTextState extends State<MongolEditableText>
             TextSelection.collapsed(offset: _value.text.length), null);
       }
     } else {
-      WidgetsBinding.instance!.removeObserver(this);
+      WidgetsBinding.instance.removeObserver(this);
       // Clear the selection and composition state if this widget lost focus.
       _value = TextEditingValue(text: _value.text);
     }
@@ -2161,7 +2161,7 @@ class MongolEditableTextState extends State<MongolEditableText>
       final size = renderEditable.size;
       final transform = renderEditable.getTransformTo(null);
       _textInputConnection!.setEditableSizeAndTransform(size, transform);
-      SchedulerBinding.instance!
+      SchedulerBinding.instance
           .addPostFrameCallback((Duration _) => _updateSizeAndTransform());
     }
   }
@@ -2185,7 +2185,7 @@ class MongolEditableTextState extends State<MongolEditableText>
             renderEditable.getLocalRectForCaret(TextPosition(offset: offset));
       }
       _textInputConnection!.setComposingRect(composingRect);
-      SchedulerBinding.instance!
+      SchedulerBinding.instance
           .addPostFrameCallback((Duration _) => _updateComposingRectIfNeeded());
     }
   }
@@ -2201,7 +2201,7 @@ class MongolEditableTextState extends State<MongolEditableText>
             renderEditable.getLocalRectForCaret(currentTextPosition);
         _textInputConnection!.setCaretRect(caretRect);
       }
-      SchedulerBinding.instance!
+      SchedulerBinding.instance
           .addPostFrameCallback((Duration _) => _updateCaretRectIfNeeded());
     }
   }

--- a/lib/src/editing/mongol_editable_text.dart
+++ b/lib/src/editing/mongol_editable_text.dart
@@ -20,6 +20,7 @@ import 'package:flutter/widgets.dart'
 //import 'package:flutter/widgets.dart' hide EditableText, EditableTextState;
 
 import 'package:mongol/src/base/mongol_text_align.dart';
+import 'package:mongol/src/editing/default_mongol_text_editing_shortcuts.dart';
 import 'package:mongol/src/editing/mongol_render_editable.dart';
 import 'package:mongol/src/editing/text_selection/mongol_text_selection.dart';
 
@@ -2243,36 +2244,6 @@ class MongolEditableTextState extends State<MongolEditableText>
   @override
   String get autofillId => 'MongolEditableText-$hashCode';
 
-  // todo editor-fixes replace with below code
-  // TextInputConfiguration _createTextInputConfiguration(
-  //     bool needsAutofillConfiguration) {
-  //   return TextInputConfiguration(
-  //     inputType: widget.keyboardType,
-  //     readOnly: widget.readOnly,
-  //     obscureText: widget.obscureText,
-  //     autocorrect: widget.autocorrect,
-  //     enableSuggestions: widget.enableSuggestions,
-  //     inputAction: widget.textInputAction ??
-  //         (widget.keyboardType == TextInputType.multiline
-  //             ? TextInputAction.newline
-  //             : TextInputAction.done),
-  //     keyboardAppearance: widget.keyboardAppearance,
-  //     autofillConfiguration: !needsAutofillConfiguration
-  //         ? null
-  //         : AutofillConfiguration(
-  //             uniqueIdentifier: autofillId,
-  //             autofillHints:
-  //                 widget.autofillHints?.toList(growable: false) ?? <String>[],
-  //             currentEditingValue: currentTextEditingValue,
-  //           ),
-  //   );
-  // }
-  //
-  // @override
-  // TextInputConfiguration get textInputConfiguration {
-  //   return _createTextInputConfiguration(_needsAutofill);
-  // }
-
   @override
   TextInputConfiguration get textInputConfiguration {
     final List<String>? autofillHints =
@@ -2511,71 +2482,73 @@ class MongolEditableTextState extends State<MongolEditableText>
     final controls = widget.selectionControls;
     return MouseRegion(
       cursor: widget.mouseCursor ?? SystemMouseCursors.text,
-      child: Actions(
-        actions: _actions,
-        child: Focus(
-          focusNode: widget.focusNode,
-          includeSemantics: false,
-          debugLabel: 'MongolEditableText',
-          child: Scrollable(
-            excludeFromSemantics: true,
-            axisDirection: _isMultiline ? AxisDirection.right : AxisDirection.down,
-            controller: _scrollController,
-            physics: widget.scrollPhysics,
-            dragStartBehavior: widget.dragStartBehavior,
-            restorationId: widget.restorationId,
-            scrollBehavior: widget.scrollBehavior ??
-                // Remove scrollbars if only single line
-                (_isMultiline
-                    ? null
-                    : ScrollConfiguration.of(context).copyWith(scrollbars: false)),
-            viewportBuilder: (BuildContext context, ViewportOffset offset) {
-              return CompositedTransformTarget(
-                link: _toolbarLayerLink,
-                child: Semantics(
-                  onCopy: _semanticsOnCopy(controls),
-                  onCut: _semanticsOnCut(controls),
-                  onPaste: _semanticsOnPaste(controls),
-                  textDirection: TextDirection.ltr,
-                  child: _MongolEditable(
-                    key: _editableKey,
-                    startHandleLayerLink: _startHandleLayerLink,
-                    endHandleLayerLink: _endHandleLayerLink,
-                    textSpan: buildTextSpan(),
-                    value: _value,
-                    cursorColor: _cursorColor,
-                    showCursor: MongolEditableText.debugDeterministicCursor
-                        ? ValueNotifier<bool>(widget.showCursor)
-                        : _cursorVisibilityNotifier,
-                    forceLine: widget.forceLine,
-                    readOnly: widget.readOnly,
-                    hasFocus: _hasFocus,
-                    maxLines: widget.maxLines,
-                    minLines: widget.minLines,
-                    expands: widget.expands,
-                    selectionColor: widget.selectionColor,
-                    textScaleFactor: widget.textScaleFactor ??
-                        MediaQuery.textScaleFactorOf(context),
-                    textAlign: widget.textAlign,
-                    obscuringCharacter: widget.obscuringCharacter,
-                    obscureText: widget.obscureText,
-                    autocorrect: widget.autocorrect,
-                    enableSuggestions: widget.enableSuggestions,
-                    offset: offset,
-                    onCaretChanged: _handleCaretChanged,
-                    rendererIgnoresPointer: widget.rendererIgnoresPointer,
-                    cursorWidth: widget.cursorWidth,
-                    cursorHeight: widget.cursorHeight,
-                    cursorRadius: widget.cursorRadius,
-                    cursorOffset: widget.cursorOffset ?? Offset.zero,
-                    enableInteractiveSelection: widget.enableInteractiveSelection,
-                    textSelectionDelegate: this,
-                    devicePixelRatio: _devicePixelRatio,
-                    clipBehavior: widget.clipBehavior,
+      child: DefaultMongolTextEditingShortcuts(
+        child: Actions(
+          actions: _actions,
+          child: Focus(
+            focusNode: widget.focusNode,
+            includeSemantics: false,
+            debugLabel: 'MongolEditableText',
+            child: Scrollable(
+              excludeFromSemantics: true,
+              axisDirection: _isMultiline ? AxisDirection.right : AxisDirection.down,
+              controller: _scrollController,
+              physics: widget.scrollPhysics,
+              dragStartBehavior: widget.dragStartBehavior,
+              restorationId: widget.restorationId,
+              scrollBehavior: widget.scrollBehavior ??
+                  // Remove scrollbars if only single line
+                  (_isMultiline
+                      ? null
+                      : ScrollConfiguration.of(context).copyWith(scrollbars: false)),
+              viewportBuilder: (BuildContext context, ViewportOffset offset) {
+                return CompositedTransformTarget(
+                  link: _toolbarLayerLink,
+                  child: Semantics(
+                    onCopy: _semanticsOnCopy(controls),
+                    onCut: _semanticsOnCut(controls),
+                    onPaste: _semanticsOnPaste(controls),
+                    textDirection: TextDirection.ltr,
+                    child: _MongolEditable(
+                      key: _editableKey,
+                      startHandleLayerLink: _startHandleLayerLink,
+                      endHandleLayerLink: _endHandleLayerLink,
+                      textSpan: buildTextSpan(),
+                      value: _value,
+                      cursorColor: _cursorColor,
+                      showCursor: MongolEditableText.debugDeterministicCursor
+                          ? ValueNotifier<bool>(widget.showCursor)
+                          : _cursorVisibilityNotifier,
+                      forceLine: widget.forceLine,
+                      readOnly: widget.readOnly,
+                      hasFocus: _hasFocus,
+                      maxLines: widget.maxLines,
+                      minLines: widget.minLines,
+                      expands: widget.expands,
+                      selectionColor: widget.selectionColor,
+                      textScaleFactor: widget.textScaleFactor ??
+                          MediaQuery.textScaleFactorOf(context),
+                      textAlign: widget.textAlign,
+                      obscuringCharacter: widget.obscuringCharacter,
+                      obscureText: widget.obscureText,
+                      autocorrect: widget.autocorrect,
+                      enableSuggestions: widget.enableSuggestions,
+                      offset: offset,
+                      onCaretChanged: _handleCaretChanged,
+                      rendererIgnoresPointer: widget.rendererIgnoresPointer,
+                      cursorWidth: widget.cursorWidth,
+                      cursorHeight: widget.cursorHeight,
+                      cursorRadius: widget.cursorRadius,
+                      cursorOffset: widget.cursorOffset ?? Offset.zero,
+                      enableInteractiveSelection: widget.enableInteractiveSelection,
+                      textSelectionDelegate: this,
+                      devicePixelRatio: _devicePixelRatio,
+                      clipBehavior: widget.clipBehavior,
+                    ),
                   ),
-                ),
-              );
-            },
+                );
+              },
+            ),
           ),
         ),
       ),

--- a/lib/src/editing/mongol_render_editable.dart
+++ b/lib/src/editing/mongol_render_editable.dart
@@ -39,11 +39,11 @@ typedef MongolSelectionChangedHandler = void Function(
 );
 
 /// The consecutive sequence of [TextPosition]s that the caret should move to
-/// when the user navigates the paragraph using the upward arrow key or the
-/// downward arrow key.
+/// when the user navigates the paragraph using the left arrow key or the
+/// right arrow key.
 ///
 /// {@template flutter.rendering.RenderEditable.verticalArrowKeyMovement}
-/// When the user presses the upward arrow key or the downward arrow key, on
+/// When the user presses the left arrow key or the right arrow key, on
 /// many platforms (macOS for instance), the caret will move to the previous
 /// line or the next line, while maintaining its original horizontal location.
 /// When it encounters a shorter line, the caret moves to the closest horizontal
@@ -51,10 +51,10 @@ typedef MongolSelectionChangedHandler = void Function(
 /// when a long enough line is encountered.
 ///
 /// Additionally, the caret will move to the beginning of the document if the
-/// upward arrow key is pressed and the caret is already on the first line. If
-/// the downward arrow key is pressed next, the caret will restore its original
+/// left arrow key is pressed and the caret is already on the first line. If
+/// the right arrow key is pressed next, the caret will restore its original
 /// horizontal location and move to the second line. Similarly the caret moves
-/// to the end of the document if the downward arrow key is pressed when it's
+/// to the end of the document if the right arrow key is pressed when it's
 /// already on the last line.
 ///
 /// Consider a top-aligned paragraph:
@@ -62,17 +62,17 @@ typedef MongolSelectionChangedHandler = void Function(
 ///   a     a
 ///  ——     a
 /// where the caret was initially placed at the end of the first line. Pressing
-/// the downward arrow key once will move the caret to the end of the second
+/// the right arrow key once will move the caret to the end of the second
 /// line, and twice the arrow key moves to the third line after the second "a"
-/// on that line. Pressing the downward arrow key again, the caret will move to
-/// the end of the third line (the end of the document). Pressing the upward
+/// on that line. Pressing the right arrow key again, the caret will move to
+/// the end of the third line (the end of the document). Pressing the left
 /// arrow key in this state will result in the caret moving to the end of the
 /// second line.
 ///
 /// Horizontal caret runs are typically interrupted when the layout of the text
 /// changes (including when the text itself changes), or when the selection is
 /// changed by other input events or programmatically (for example, when the
-/// user pressed the left arrow key).
+/// user pressed the up arrow key).
 /// {@endtemplate}
 ///
 /// The [movePrevious] method moves the caret location (which is
@@ -85,7 +85,7 @@ typedef MongolSelectionChangedHandler = void Function(
 /// the [HorizontalCaretMovementRun] must not be used. The [isValid] property must
 /// be checked before calling [movePrevious] and [moveNext], or accessing
 /// [current].
-class HorizontalCaretMovementRun extends BidirectionalIterator<TextPosition> {
+class HorizontalCaretMovementRun extends Iterator<TextPosition> {
   HorizontalCaretMovementRun._(
       this._editable,
       this._lineMetrics,
@@ -159,7 +159,6 @@ class HorizontalCaretMovementRun extends BidirectionalIterator<TextPosition> {
     return true;
   }
 
-  @override
   bool movePrevious() {
     assert(isValid);
     if (_currentLine <= 0) {
@@ -1996,7 +1995,7 @@ class MongolRenderEditable extends RenderBox
   /// Starts a [HorizontalCaretMovementRun] at the given location in the text, for
   /// handling consecutive horizontal caret movements.
   ///
-  /// This can be used to handle consecutive upward/downward arrow key movements
+  /// This can be used to handle consecutive left/right arrow key movements
   /// in an input field.
   ///
   /// {@macro flutter.rendering.RenderEditable.verticalArrowKeyMovement}

--- a/lib/src/editing/mongol_text_field.dart
+++ b/lib/src/editing/mongol_text_field.dart
@@ -277,12 +277,6 @@ class _TextFieldSelectionGestureDetectorBuilder
 ///    [MongolTextField]. The [MongolEditableText] widget is rarely used directly unless
 ///    you are implementing an entirely different design language, such as
 ///    Cupertino.
-@Deprecated("Don't use this class with Flutter 2.5 or higher. Something in the "
-    "Flutter 2.5 update causes your app to freeze if the cursor has to scroll out "
-    "of view. As a workaround for single line text you can rotate a standard "
-    "TextField. There is no current workaround for multiline text. If you can find "
-    "the source of the error please open an issue on GitHub. The error is "
-    "apparently in EditableText")
 class MongolTextField extends StatefulWidget {
   /// Creates a Material Design text field for vertical Mongolian text.
   ///

--- a/lib/src/editing/text_selection/mongol_text_selection.dart
+++ b/lib/src/editing/text_selection/mongol_text_selection.dart
@@ -159,9 +159,9 @@ class MongolTextSelectionOverlay {
     _handlesVisible = visible;
     // If we are in build state, it will be too late to update visibility.
     // We will need to schedule the build in next frame.
-    if (SchedulerBinding.instance!.schedulerPhase ==
+    if (SchedulerBinding.instance.schedulerPhase ==
         SchedulerPhase.persistentCallbacks) {
-      SchedulerBinding.instance!.addPostFrameCallback(_markNeedsBuild);
+      SchedulerBinding.instance.addPostFrameCallback(_markNeedsBuild);
     } else {
       _markNeedsBuild();
     }
@@ -216,9 +216,9 @@ class MongolTextSelectionOverlay {
   void update(TextEditingValue newValue) {
     if (_value == newValue) return;
     _value = newValue;
-    if (SchedulerBinding.instance!.schedulerPhase ==
+    if (SchedulerBinding.instance.schedulerPhase ==
         SchedulerPhase.persistentCallbacks) {
-      SchedulerBinding.instance!.addPostFrameCallback(_markNeedsBuild);
+      SchedulerBinding.instance.addPostFrameCallback(_markNeedsBuild);
     } else {
       _markNeedsBuild();
     }

--- a/lib/src/menu/mongol_tooltip.dart
+++ b/lib/src/menu/mongol_tooltip.dart
@@ -276,18 +276,18 @@ class _MongolTooltipState extends State<MongolTooltip>
   @override
   void initState() {
     super.initState();
-    _mouseIsConnected = RendererBinding.instance!.mouseTracker.mouseIsConnected;
+    _mouseIsConnected = RendererBinding.instance.mouseTracker.mouseIsConnected;
     _controller = AnimationController(
       duration: _fadeInDuration,
       reverseDuration: _fadeOutDuration,
       vsync: this,
     )..addStatusListener(_handleStatusChanged);
     // Listen to see when a mouse is added.
-    RendererBinding.instance!.mouseTracker
+    RendererBinding.instance.mouseTracker
         .addListener(_handleMouseTrackerChange);
     // Listen to global pointer events so that we can hide a tooltip immediately
     // if some other control is clicked on.
-    GestureBinding.instance!.pointerRouter.addGlobalRoute(_handlePointerEvent);
+    GestureBinding.instance.pointerRouter.addGlobalRoute(_handlePointerEvent);
   }
 
   // https://material.io/components/tooltips#specs
@@ -333,7 +333,7 @@ class _MongolTooltipState extends State<MongolTooltip>
       return;
     }
     final bool mouseIsConnected =
-        RendererBinding.instance!.mouseTracker.mouseIsConnected;
+        RendererBinding.instance.mouseTracker.mouseIsConnected;
     if (mouseIsConnected != _mouseIsConnected) {
       setState(() {
         _mouseIsConnected = mouseIsConnected;
@@ -463,9 +463,9 @@ class _MongolTooltipState extends State<MongolTooltip>
 
   @override
   void dispose() {
-    GestureBinding.instance!.pointerRouter
+    GestureBinding.instance.pointerRouter
         .removeGlobalRoute(_handlePointerEvent);
-    RendererBinding.instance!.mouseTracker
+    RendererBinding.instance.mouseTracker
         .removeListener(_handleMouseTrackerChange);
     if (_entry != null) {
       _removeEntry();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -42,14 +42,14 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: "direct dev"
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -87,7 +87,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: "direct dev"
     description:
@@ -101,7 +101,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -113,7 +113,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: "direct dev"
     description:
@@ -148,20 +148,13 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.9"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"


### PR DESCRIPTION
Using `RawKeyboard.instance.addListener` in `MongolRenderEditable` caused the `Focus` widget to fail to intercept keyboard events.

In Flutter latest version, this is replaced with `Actions` and `Shortcuts`.  Most of code are copied from Flutter source.

There are still have some logic to test and discuss:

* Implementation of `computeLineMetrics` method in `MongolParagraph`.
* Find a way to swap up/down keys and left/right keys on `Web`.
* Caret position is wrong when `textAlign` set to other `MongolTextAlign.top`.
* Need further testing.