### PR TITLE
Remove DefaultMongolTextEditingShortcuts from MongolEditableTextState

### DIFF
--- a/example/lib/demos/input_shortcuts_demo.dart
+++ b/example/lib/demos/input_shortcuts_demo.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:mongol/mongol.dart';
+
+class InputShortcutsDemo extends StatefulWidget {
+  const InputShortcutsDemo({super.key});
+
+  @override
+  State<StatefulWidget> createState() => _InputShortcutsDemoState();
+}
+
+class _InputShortcutsDemoState extends State<InputShortcutsDemo> {
+  final mongolInputController = TextEditingController(text: '''
+// arrowUp arrowDown
+// arrowLeft arrowRight
+// macos ios meta
+// windows android fushia control
+// alt
+// + shift''');
+  final systemInputController = TextEditingController(text: '''
+// arrowUp arrowDown
+// arrowLeft arrowRight
+// macos ios meta
+// windows android fushia control
+// alt
+// + shift''');
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Input Shortcuts')),
+      body: Row(
+        children: [
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: MongolTextField(
+                controller: mongolInputController,
+                maxLines: null,
+                textAlignHorizontal: TextAlignHorizontal.left,
+                expands: true,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: TextField(
+                controller: systemInputController,
+                maxLines: null,
+                textAlignVertical: TextAlignVertical.top,
+                expands: true,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,18 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:mongol/mongol.dart';
 
-import 'demos/horizontal_listview_demo.dart';
 import 'demos/alert_dialog_demo.dart';
 import 'demos/button_demo.dart';
 import 'demos/emoji_cjk_demo.dart';
+import 'demos/horizontal_listview_demo.dart';
 import 'demos/input_decorations_demo.dart';
+import 'demos/input_shortcuts_demo.dart';
 import 'demos/keyboard_demo.dart';
 import 'demos/list_tile_demo.dart';
 import 'demos/max_lines_demo.dart';
 import 'demos/mongol_text_field_demo.dart';
 import 'demos/popup_menu_demo.dart';
+import 'demos/resizable_text_demo.dart';
 import 'demos/text_demo.dart';
 import 'demos/text_span_demo.dart';
-import 'demos/resizable_text_demo.dart';
 
 void main() {
   runApp(const DemoApp());
@@ -20,10 +22,14 @@ void main() {
 
 class DemoApp extends StatelessWidget {
   const DemoApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
+      builder: (context, child) {
+        return DefaultMongolTextEditingShortcuts(child: child);
+      },
       title: 'mongol',
       theme: ThemeData(
         fontFamily: 'MenksoftQagan',
@@ -38,6 +44,7 @@ class DemoApp extends StatelessWidget {
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return ListView(
@@ -61,6 +68,10 @@ class HomeScreen extends StatelessWidget {
         DemoTile(
           title: 'Input decoration',
           destination: InputDecorationsDemo(),
+        ),
+        DemoTile(
+          title: 'Input Shortcuts',
+          destination: InputShortcutsDemo(),
         ),
         DemoTile(
           title: 'MongolAlertDialog',

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -28,7 +28,7 @@ class DemoApp extends StatelessWidget {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       builder: (context, child) {
-        return DefaultMongolTextEditingShortcuts(child: child);
+        return MongolTextEditingShortcuts(child: child);
       },
       title: 'mongol',
       theme: ThemeData(

--- a/lib/mongol.dart
+++ b/lib/mongol.dart
@@ -1,19 +1,20 @@
 library mongol;
 
-export 'package:mongol/src/text/mongol_text.dart';
-export 'package:mongol/src/text/mongol_rich_text.dart';
 export 'package:mongol/src/base/mongol_text_align.dart';
 export 'package:mongol/src/base/mongol_text_painter.dart';
+export 'package:mongol/src/button/mongol_elevated_button.dart';
+export 'package:mongol/src/button/mongol_icon_button.dart';
+export 'package:mongol/src/button/mongol_outlined_button.dart';
+export 'package:mongol/src/button/mongol_text_button.dart';
 export 'package:mongol/src/dialog/mongol_alert_dialog.dart';
-export 'package:mongol/src/editing/mongol_text_field.dart';
-export 'package:mongol/src/editing/mongol_render_editable.dart';
 export 'package:mongol/src/editing/alignment.dart';
+export 'package:mongol/src/editing/default_mongol_text_editing_shortcuts.dart';
 export 'package:mongol/src/editing/input_border.dart'
     show SidelineInputBorder, MongolOutlineInputBorder;
+export 'package:mongol/src/editing/mongol_render_editable.dart';
+export 'package:mongol/src/editing/mongol_text_field.dart';
+export 'package:mongol/src/list/mongol_list_tile.dart';
 export 'package:mongol/src/menu/mongol_popup_menu.dart';
 export 'package:mongol/src/menu/mongol_tooltip.dart';
-export 'package:mongol/src/list/mongol_list_tile.dart';
-export 'package:mongol/src/button/mongol_icon_button.dart';
-export 'package:mongol/src/button/mongol_text_button.dart';
-export 'package:mongol/src/button/mongol_outlined_button.dart';
-export 'package:mongol/src/button/mongol_elevated_button.dart';
+export 'package:mongol/src/text/mongol_rich_text.dart';
+export 'package:mongol/src/text/mongol_text.dart';

--- a/lib/mongol.dart
+++ b/lib/mongol.dart
@@ -8,10 +8,10 @@ export 'package:mongol/src/button/mongol_outlined_button.dart';
 export 'package:mongol/src/button/mongol_text_button.dart';
 export 'package:mongol/src/dialog/mongol_alert_dialog.dart';
 export 'package:mongol/src/editing/alignment.dart';
-export 'package:mongol/src/editing/default_mongol_text_editing_shortcuts.dart';
 export 'package:mongol/src/editing/input_border.dart'
     show SidelineInputBorder, MongolOutlineInputBorder;
 export 'package:mongol/src/editing/mongol_render_editable.dart';
+export 'package:mongol/src/editing/mongol_text_editing_shortcuts.dart';
 export 'package:mongol/src/editing/mongol_text_field.dart';
 export 'package:mongol/src/list/mongol_list_tile.dart';
 export 'package:mongol/src/menu/mongol_popup_menu.dart';

--- a/lib/src/editing/default_mongol_text_editing_shortcuts.dart
+++ b/lib/src/editing/default_mongol_text_editing_shortcuts.dart
@@ -4,19 +4,18 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 
-/// Swap up/down arrow keys and left/right arrow keys on platforms other than the web.
-/// [DefaultTextEditingShortcuts._webDisablingTextShortcuts] said, "Web handles
-/// its text selection natively and doesn't use any of these shortcuts in Flutter".
-/// so maybe there is no way to swap these keys, but I'm not sure.
+import 'mongol_text_editing_intents.dart';
+
+/// Switch up/down arrow keys and left/right arrow keys
 class DefaultMongolTextEditingShortcuts extends StatelessWidget {
   const DefaultMongolTextEditingShortcuts({Key? key, required this.child})
       : super(key: key);
 
-  final Widget child;
+  final Widget? child;
 
   // These are shortcuts are shared between most platforms except macOS for it
   // uses different modifier keys as the line/word modifier.
@@ -24,73 +23,73 @@ class DefaultMongolTextEditingShortcuts extends StatelessWidget {
       <ShortcutActivator, Intent>{
     // Arrow: Move Selection.
     const SingleActivator(LogicalKeyboardKey.arrowUp):
-        const ExtendSelectionByCharacterIntent(
+        const MongolExtendSelectionByCharacterIntent(
             forward: false, collapseSelection: true),
     const SingleActivator(LogicalKeyboardKey.arrowDown):
-        const ExtendSelectionByCharacterIntent(
+        const MongolExtendSelectionByCharacterIntent(
             forward: true, collapseSelection: true),
     const SingleActivator(LogicalKeyboardKey.arrowLeft):
-        const ExtendSelectionVerticallyToAdjacentLineIntent(
+        const MongolExtendSelectionHorizontallyToAdjacentLineIntent(
             forward: false, collapseSelection: true),
     const SingleActivator(LogicalKeyboardKey.arrowRight):
-        const ExtendSelectionVerticallyToAdjacentLineIntent(
+        const MongolExtendSelectionHorizontallyToAdjacentLineIntent(
             forward: true, collapseSelection: true),
 
     // Shift + Arrow: Extend Selection.
     const SingleActivator(LogicalKeyboardKey.arrowUp, shift: true):
-        const ExtendSelectionByCharacterIntent(
+        const MongolExtendSelectionByCharacterIntent(
             forward: false, collapseSelection: false),
     const SingleActivator(LogicalKeyboardKey.arrowDown, shift: true):
-        const ExtendSelectionByCharacterIntent(
+        const MongolExtendSelectionByCharacterIntent(
             forward: true, collapseSelection: false),
     const SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true):
-        const ExtendSelectionVerticallyToAdjacentLineIntent(
+        const MongolExtendSelectionHorizontallyToAdjacentLineIntent(
             forward: false, collapseSelection: false),
     const SingleActivator(LogicalKeyboardKey.arrowRight, shift: true):
-        const ExtendSelectionVerticallyToAdjacentLineIntent(
+        const MongolExtendSelectionHorizontallyToAdjacentLineIntent(
             forward: true, collapseSelection: false),
 
     const SingleActivator(LogicalKeyboardKey.arrowUp, alt: true):
-        const ExtendSelectionToLineBreakIntent(
+        const MongolExtendSelectionToLineBreakIntent(
             forward: false, collapseSelection: true),
     const SingleActivator(LogicalKeyboardKey.arrowDown, alt: true):
-        const ExtendSelectionToLineBreakIntent(
+        const MongolExtendSelectionToLineBreakIntent(
             forward: true, collapseSelection: true),
     const SingleActivator(LogicalKeyboardKey.arrowLeft, alt: true):
-        const ExtendSelectionToDocumentBoundaryIntent(
+        const MongolExtendSelectionToDocumentBoundaryIntent(
             forward: false, collapseSelection: true),
     const SingleActivator(LogicalKeyboardKey.arrowRight, alt: true):
-        const ExtendSelectionToDocumentBoundaryIntent(
+        const MongolExtendSelectionToDocumentBoundaryIntent(
             forward: true, collapseSelection: true),
 
     const SingleActivator(LogicalKeyboardKey.arrowUp, shift: true, alt: true):
-        const ExtendSelectionToLineBreakIntent(
+        const MongolExtendSelectionToLineBreakIntent(
             forward: false, collapseSelection: false),
     const SingleActivator(LogicalKeyboardKey.arrowDown, shift: true, alt: true):
-        const ExtendSelectionToLineBreakIntent(
+        const MongolExtendSelectionToLineBreakIntent(
             forward: true, collapseSelection: false),
     const SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true, alt: true):
-        const ExtendSelectionToDocumentBoundaryIntent(
+        const MongolExtendSelectionToDocumentBoundaryIntent(
             forward: false, collapseSelection: false),
     const SingleActivator(LogicalKeyboardKey.arrowRight,
             shift: true, alt: true):
-        const ExtendSelectionToDocumentBoundaryIntent(
+        const MongolExtendSelectionToDocumentBoundaryIntent(
             forward: true, collapseSelection: false),
 
     const SingleActivator(LogicalKeyboardKey.arrowUp, control: true):
-        const ExtendSelectionToNextWordBoundaryIntent(
+        const MongolExtendSelectionToNextWordBoundaryIntent(
             forward: false, collapseSelection: true),
     const SingleActivator(LogicalKeyboardKey.arrowDown, control: true):
-        const ExtendSelectionToNextWordBoundaryIntent(
+        const MongolExtendSelectionToNextWordBoundaryIntent(
             forward: true, collapseSelection: true),
 
     const SingleActivator(LogicalKeyboardKey.arrowUp,
             shift: true, control: true):
-        const ExtendSelectionToNextWordBoundaryIntent(
+        const MongolExtendSelectionToNextWordBoundaryIntent(
             forward: false, collapseSelection: false),
     const SingleActivator(LogicalKeyboardKey.arrowDown,
             shift: true, control: true):
-        const ExtendSelectionToNextWordBoundaryIntent(
+        const MongolExtendSelectionToNextWordBoundaryIntent(
             forward: true, collapseSelection: false),
   };
 
@@ -126,84 +125,84 @@ class DefaultMongolTextEditingShortcuts extends StatelessWidget {
   static final Map<ShortcutActivator, Intent> _macShortcuts =
       <ShortcutActivator, Intent>{
     const SingleActivator(LogicalKeyboardKey.arrowUp):
-        const ExtendSelectionByCharacterIntent(
+        const MongolExtendSelectionByCharacterIntent(
             forward: false, collapseSelection: true),
     const SingleActivator(LogicalKeyboardKey.arrowDown):
-        const ExtendSelectionByCharacterIntent(
+        const MongolExtendSelectionByCharacterIntent(
             forward: true, collapseSelection: true),
     const SingleActivator(LogicalKeyboardKey.arrowLeft):
-        const ExtendSelectionVerticallyToAdjacentLineIntent(
+        const MongolExtendSelectionHorizontallyToAdjacentLineIntent(
             forward: false, collapseSelection: true),
     const SingleActivator(LogicalKeyboardKey.arrowRight):
-        const ExtendSelectionVerticallyToAdjacentLineIntent(
+        const MongolExtendSelectionHorizontallyToAdjacentLineIntent(
             forward: true, collapseSelection: true),
 
     // Shift + Arrow: Extend Selection.
     const SingleActivator(LogicalKeyboardKey.arrowUp, shift: true):
-        const ExtendSelectionByCharacterIntent(
+        const MongolExtendSelectionByCharacterIntent(
             forward: false, collapseSelection: false),
     const SingleActivator(LogicalKeyboardKey.arrowDown, shift: true):
-        const ExtendSelectionByCharacterIntent(
+        const MongolExtendSelectionByCharacterIntent(
             forward: true, collapseSelection: false),
     const SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true):
-        const ExtendSelectionVerticallyToAdjacentLineIntent(
+        const MongolExtendSelectionHorizontallyToAdjacentLineIntent(
             forward: false, collapseSelection: false),
     const SingleActivator(LogicalKeyboardKey.arrowRight, shift: true):
-        const ExtendSelectionVerticallyToAdjacentLineIntent(
+        const MongolExtendSelectionHorizontallyToAdjacentLineIntent(
             forward: true, collapseSelection: false),
 
     const SingleActivator(LogicalKeyboardKey.arrowUp, alt: true):
-        const ExtendSelectionToNextWordBoundaryIntent(
+        const MongolExtendSelectionToNextWordBoundaryIntent(
             forward: false, collapseSelection: true),
     const SingleActivator(LogicalKeyboardKey.arrowDown, alt: true):
-        const ExtendSelectionToNextWordBoundaryIntent(
+        const MongolExtendSelectionToNextWordBoundaryIntent(
             forward: true, collapseSelection: true),
     const SingleActivator(LogicalKeyboardKey.arrowLeft, alt: true):
-        const ExtendSelectionToLineBreakIntent(
+        const MongolExtendSelectionToLineBreakIntent(
             forward: false, collapseSelection: true),
     const SingleActivator(LogicalKeyboardKey.arrowRight, alt: true):
-        const ExtendSelectionToLineBreakIntent(
+        const MongolExtendSelectionToLineBreakIntent(
             forward: true, collapseSelection: true),
 
     const SingleActivator(LogicalKeyboardKey.arrowUp, shift: true, alt: true):
-        const ExtendSelectionToNextWordBoundaryOrCaretLocationIntent(
+        const MongolExtendSelectionToNextWordBoundaryOrCaretLocationIntent(
             forward: false),
     const SingleActivator(LogicalKeyboardKey.arrowDown, shift: true, alt: true):
-        const ExtendSelectionToNextWordBoundaryOrCaretLocationIntent(
+        const MongolExtendSelectionToNextWordBoundaryOrCaretLocationIntent(
             forward: true),
     const SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true, alt: true):
-        const ExtendSelectionToLineBreakIntent(
+        const MongolExtendSelectionToLineBreakIntent(
             forward: false, collapseSelection: false, collapseAtReversal: true),
     const SingleActivator(LogicalKeyboardKey.arrowRight,
             shift: true, alt: true):
-        const ExtendSelectionToLineBreakIntent(
+        const MongolExtendSelectionToLineBreakIntent(
             forward: true, collapseSelection: false, collapseAtReversal: true),
 
     const SingleActivator(LogicalKeyboardKey.arrowUp, meta: true):
-        const ExtendSelectionToLineBreakIntent(
+        const MongolExtendSelectionToLineBreakIntent(
             forward: false, collapseSelection: true),
     const SingleActivator(LogicalKeyboardKey.arrowDown, meta: true):
-        const ExtendSelectionToLineBreakIntent(
+        const MongolExtendSelectionToLineBreakIntent(
             forward: true, collapseSelection: true),
     const SingleActivator(LogicalKeyboardKey.arrowLeft, meta: true):
-        const ExtendSelectionToDocumentBoundaryIntent(
+        const MongolExtendSelectionToDocumentBoundaryIntent(
             forward: false, collapseSelection: true),
     const SingleActivator(LogicalKeyboardKey.arrowRight, meta: true):
-        const ExtendSelectionToDocumentBoundaryIntent(
+        const MongolExtendSelectionToDocumentBoundaryIntent(
             forward: true, collapseSelection: true),
 
     const SingleActivator(LogicalKeyboardKey.arrowUp, shift: true, meta: true):
-        const ExpandSelectionToLineBreakIntent(forward: false),
+        const MongolExpandSelectionToLineBreakIntent(forward: false),
     const SingleActivator(LogicalKeyboardKey.arrowDown,
-        shift: true,
-        meta: true): const ExpandSelectionToLineBreakIntent(forward: true),
+            shift: true, meta: true):
+        const MongolExpandSelectionToLineBreakIntent(forward: true),
     const SingleActivator(LogicalKeyboardKey.arrowLeft,
             shift: true, meta: true):
-        const ExtendSelectionToDocumentBoundaryIntent(
+        const MongolExtendSelectionToDocumentBoundaryIntent(
             forward: false, collapseSelection: false),
     const SingleActivator(LogicalKeyboardKey.arrowRight,
             shift: true, meta: true):
-        const ExtendSelectionToDocumentBoundaryIntent(
+        const MongolExtendSelectionToDocumentBoundaryIntent(
             forward: true, collapseSelection: false),
   };
 
@@ -214,7 +213,7 @@ class DefaultMongolTextEditingShortcuts extends StatelessWidget {
   static final Map<ShortcutActivator, Intent> _windowsShortcuts =
       _commonShortcuts;
 
-  static Map<ShortcutActivator, Intent> get _shortcuts {
+  static Map<ShortcutActivator, Intent> get shortcuts {
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
         return _androidShortcuts;
@@ -231,147 +230,11 @@ class DefaultMongolTextEditingShortcuts extends StatelessWidget {
     }
   }
 
-  // Web handles its text selection natively and doesn't use any of these
-  // shortcuts in Flutter.
-  static final Map<ShortcutActivator, Intent> _webDisablingTextShortcuts =
-      <ShortcutActivator, Intent>{
-    for (final bool pressShift in const <bool>[
-      true,
-      false
-    ]) ...<SingleActivator, Intent>{
-      SingleActivator(LogicalKeyboardKey.backspace, shift: pressShift):
-          const DoNothingAndStopPropagationTextIntent(),
-      SingleActivator(LogicalKeyboardKey.delete, shift: pressShift):
-          const DoNothingAndStopPropagationTextIntent(),
-      SingleActivator(LogicalKeyboardKey.backspace,
-          alt: true,
-          shift: pressShift): const DoNothingAndStopPropagationTextIntent(),
-      SingleActivator(LogicalKeyboardKey.delete, alt: true, shift: pressShift):
-          const DoNothingAndStopPropagationTextIntent(),
-      SingleActivator(LogicalKeyboardKey.backspace,
-          control: true,
-          shift: pressShift): const DoNothingAndStopPropagationTextIntent(),
-      SingleActivator(LogicalKeyboardKey.delete,
-          control: true,
-          shift: pressShift): const DoNothingAndStopPropagationTextIntent(),
-      SingleActivator(LogicalKeyboardKey.backspace,
-          meta: true,
-          shift: pressShift): const DoNothingAndStopPropagationTextIntent(),
-      SingleActivator(LogicalKeyboardKey.delete, meta: true, shift: pressShift):
-          const DoNothingAndStopPropagationTextIntent(),
-    },
-    const SingleActivator(LogicalKeyboardKey.arrowDown, alt: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowLeft, alt: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowRight, alt: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowUp, alt: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowDown, shift: true, alt: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true, alt: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowRight,
-        shift: true, alt: true): const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowUp, shift: true, alt: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowDown):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowLeft):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowRight):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowUp):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowLeft, control: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowRight, control: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowLeft,
-        shift: true,
-        control: true): const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowRight,
-        shift: true,
-        control: true): const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.end):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.home):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowDown, meta: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowLeft, meta: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowRight, meta: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowUp, meta: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowDown,
-        shift: true, meta: true): const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowLeft,
-        shift: true, meta: true): const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowRight,
-        shift: true, meta: true): const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowUp, shift: true, meta: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowDown, shift: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowRight, shift: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.arrowUp, shift: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.end, shift: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.home, shift: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.end, control: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.home, control: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.space):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.enter):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.keyX, control: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.keyX, meta: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.keyC, control: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.keyC, meta: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.keyV, control: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.keyV, meta: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.keyA, control: true):
-        const DoNothingAndStopPropagationTextIntent(),
-    const SingleActivator(LogicalKeyboardKey.keyA, meta: true):
-        const DoNothingAndStopPropagationTextIntent(),
-  };
-
   @override
   Widget build(BuildContext context) {
-    Widget result = child;
-    if (kIsWeb) {
-      // On the web, these shortcuts make sure of the following:
-      //
-      // 1. Shortcuts fired when an EditableText is focused are ignored and
-      //    forwarded to the browser by the EditableText's Actions, because it
-      //    maps DoNothingAndStopPropagationTextIntent to DoNothingAction.
-      // 2. Shortcuts fired when no EditableText is focused will still trigger
-      //    _shortcuts assuming DoNothingAndStopPropagationTextIntent is
-      //    unhandled elsewhere.
-      result = Shortcuts(
-          debugLabel: '<Web Disabling Text Editing Shortcuts>',
-          shortcuts: _webDisablingTextShortcuts,
-          child: result);
-    }
     return Shortcuts(
-        debugLabel: '<Default Text Editing Shortcuts>',
-        shortcuts: _shortcuts,
-        child: result);
+        debugLabel: '<Default Mongol Text Editing Shortcuts>',
+        shortcuts: shortcuts,
+        child: child ?? const SizedBox.shrink());
   }
 }

--- a/lib/src/editing/mongol_text_editing_intents.dart
+++ b/lib/src/editing/mongol_text_editing_intents.dart
@@ -1,0 +1,105 @@
+// Copyright 2014 The Flutter Authors.
+// Copyright 2021 Suragch.
+// All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+
+/// Extends, or moves the current selection from the current
+/// [TextSelection.extent] position to the previous or the next character
+/// boundary.
+class MongolExtendSelectionByCharacterIntent
+    extends ExtendSelectionByCharacterIntent {
+  /// Creates an [MongolExtendSelectionByCharacterIntent].
+  const MongolExtendSelectionByCharacterIntent(
+      {required super.forward, required super.collapseSelection});
+}
+
+/// Extends, or moves the current selection from the current
+/// [TextSelection.extent] position to the closest position on the adjacent
+/// line.
+class MongolExtendSelectionHorizontallyToAdjacentLineIntent
+    extends ExtendSelectionVerticallyToAdjacentLineIntent {
+  /// Creates an [MongolExtendSelectionHorizontallyToAdjacentLineIntent].
+  const MongolExtendSelectionHorizontallyToAdjacentLineIntent(
+      {required super.forward, required super.collapseSelection});
+}
+
+/// Expands the current selection to the closest line break in the direction
+/// given by [forward].
+///
+/// Either the base or extent can move, whichever is closer to the line break.
+/// The selection will never shrink.
+///
+/// This behavior is common on MacOS.
+///
+/// See also:
+///
+///   [MongolExtendSelectionToLineBreakIntent], which is similar but always moves the
+///   extent.
+class MongolExpandSelectionToLineBreakIntent
+    extends ExpandSelectionToLineBreakIntent {
+  /// Creates an [MongolExpandSelectionToLineBreakIntent].
+  const MongolExpandSelectionToLineBreakIntent({required super.forward});
+}
+
+/// Extends, or moves the current selection from the current
+/// [TextSelection.extent] position to the closest line break in the direction
+/// given by [forward].
+///
+/// See also:
+///
+///   [ExpandSelectionToLineBreakIntent], which is similar but always increases
+///   the size of the selection.
+class MongolExtendSelectionToLineBreakIntent
+    extends ExtendSelectionToLineBreakIntent {
+  /// Creates an [MongolExtendSelectionToLineBreakIntent].
+  const MongolExtendSelectionToLineBreakIntent(
+      {required super.forward,
+      required super.collapseSelection,
+      super.collapseAtReversal,
+      super.continuesAtWrap});
+}
+
+/// Extends, or moves the current selection from the current
+/// [TextSelection.extent] position to the start or the end of the document.
+///
+/// See also:
+///
+///   [ExtendSelectionToDocumentBoundaryIntent], which is similar but always
+///   increases the size of the selection.
+class MongolExtendSelectionToDocumentBoundaryIntent
+    extends ExtendSelectionToDocumentBoundaryIntent {
+  /// Creates an [MongolExtendSelectionToDocumentBoundaryIntent].
+  const MongolExtendSelectionToDocumentBoundaryIntent(
+      {required super.forward, required super.collapseSelection});
+}
+
+/// Extends, or moves the current selection from the current
+/// [TextSelection.extent] position to the previous or the next word
+/// boundary.
+class MongolExtendSelectionToNextWordBoundaryIntent
+    extends ExtendSelectionToNextWordBoundaryIntent {
+  /// Creates an [MongolExtendSelectionToNextWordBoundaryIntent].
+  const MongolExtendSelectionToNextWordBoundaryIntent(
+      {required super.forward, required super.collapseSelection});
+}
+
+/// Extends, or moves the current selection from the current
+/// [TextSelection.extent] position to the previous or the next word
+/// boundary, or the [TextSelection.base] position if it's closer in the move
+/// direction.
+///
+/// This [Intent] typically has the same effect as an
+/// [MongolExtendSelectionToNextWordBoundaryIntent], except it collapses the selection
+/// when the order of [TextSelection.base] and [TextSelection.extent] would
+/// reverse.
+///
+/// This is typically only used on MacOS.
+class MongolExtendSelectionToNextWordBoundaryOrCaretLocationIntent
+    extends ExtendSelectionToNextWordBoundaryOrCaretLocationIntent {
+  /// Creates an [MongolExtendSelectionToNextWordBoundaryOrCaretLocationIntent].
+  const MongolExtendSelectionToNextWordBoundaryOrCaretLocationIntent(
+      {required super.forward});
+}

--- a/lib/src/editing/mongol_text_editing_shortcuts.dart
+++ b/lib/src/editing/mongol_text_editing_shortcuts.dart
@@ -11,8 +11,8 @@ import 'package:flutter/widgets.dart';
 import 'mongol_text_editing_intents.dart';
 
 /// Switch up/down arrow keys and left/right arrow keys
-class DefaultMongolTextEditingShortcuts extends StatelessWidget {
-  const DefaultMongolTextEditingShortcuts({Key? key, required this.child})
+class MongolTextEditingShortcuts extends StatelessWidget {
+  const MongolTextEditingShortcuts({Key? key, required this.child})
       : super(key: key);
 
   final Widget? child;
@@ -233,7 +233,7 @@ class DefaultMongolTextEditingShortcuts extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Shortcuts(
-        debugLabel: '<Default Mongol Text Editing Shortcuts>',
+        debugLabel: '<Mongol Text Editing Shortcuts>',
         shortcuts: shortcuts,
         child: child ?? const SizedBox.shrink());
   }


### PR DESCRIPTION
* Remove DefaultMongolTextEditingShortcuts to prevent it intercept keyboard event

* If developers using this library need to switch up/down and left/right keys, insert DefaultMongolTextEditingShortcuts to WidgetsApp's builder. Use one of these.
   ```dart
   WidgetsApp(
      ...
      builder: (context, child) {
        return DefaultMongolTextEditingShortcuts(child: child);
      },
      ...
   )
   ```

   ```dart
  MaterialApp(
      ...
      builder: (context, child) {
        return DefaultMongolTextEditingShortcuts(child: child);
      },
      ...
   )
   ```

   ```dart
  CupertinoApp(
      ...
      builder: (context, child) {
        return DefaultMongolTextEditingShortcuts(child: child);
      },
      ...
   )
   ```

> This is the second solution that is mentioned in #33. The last solution is not working. Such as, in `TextField`, `left/right+alt` and `up/down+meta` will invoke `ExtendSelectionToLineBreakIntent` and `up/down+alt` will invoke `ExtendSelectionToNextWordBoundaryIntent`. In `MongolTextField` we will switch `ExtendSelectionToLineBreakIntent` and `ExtendSelectionToNextWordBoundaryIntent` to switch  `left/right+alt` and `up/down+alt`. However, `ExtendSelectionToLineBreakIntent` also means pressing `up/down+meta`. This is a conflict and solving it is complex.