### PR TITLE
Fix Flutter 3.44 compatibility and add horizontal page navigation

### DIFF
--- a/lib/src/editing/mongol_editable_text.dart
+++ b/lib/src/editing/mongol_editable_text.dart
@@ -64,7 +64,6 @@ import 'package:flutter/widgets.dart'
         EdgeInsets,
         ExpandSelectionToLineBreakIntent,
         ExtendSelectionByCharacterIntent,
-        ExtendSelectionByPageIntent,
         ExtendSelectionToDocumentBoundaryIntent,
         ExtendSelectionToLineBreakIntent,
         ExtendSelectionToNextWordBoundaryIntent,
@@ -3306,14 +3305,13 @@ class MongolEditableTextState extends State<MongolEditableText>
     _scrollController.jumpTo(destination);
   }
 
-  /// Extend the selection down by page if the `forward` parameter is true, or
-  /// up by page otherwise.
-  void _extendSelectionByPage(ExtendSelectionByPageIntent intent) {
+  /// Extends the selection horizontally by one page.
+  void _extendSelectionHorizontallyByPage(
+      MongolExtendSelectionHorizontallyToAdjacentPageIntent intent) {
     if (widget.maxLines == 1) {
       return;
     }
 
-    final TextSelection nextSelection;
     final Rect extentRect = renderEditable.getLocalRectForCaret(
       _value.selection.extent,
     );
@@ -3327,6 +3325,8 @@ class MongolEditableTextState extends State<MongolEditableText>
       ),
     );
     final ScrollPosition position = _scrollController.position;
+
+    final TextPosition nextExtent;
     if (intent.forward) {
       if (_value.selection.extentOffset >= _value.text.length) {
         return;
@@ -3334,31 +3334,32 @@ class MongolEditableTextState extends State<MongolEditableText>
       final Offset nextExtentOffset =
           Offset(extentRect.left + increment, extentRect.top);
       final double width = position.maxScrollExtent + renderEditable.size.width;
-      final TextPosition nextExtent =
-          nextExtentOffset.dx + position.pixels >= width
-              ? TextPosition(offset: _value.text.length)
-              : renderEditable.getPositionForPoint(
-                  renderEditable.localToGlobal(nextExtentOffset),
-                );
-      nextSelection = _value.selection.copyWith(
-        extentOffset: nextExtent.offset,
-      );
+      nextExtent = nextExtentOffset.dx + position.pixels >= width
+          ? TextPosition(offset: _value.text.length)
+          : renderEditable.getPositionForPoint(
+              renderEditable.localToGlobal(nextExtentOffset),
+            );
     } else {
       if (_value.selection.extentOffset <= 0) {
         return;
       }
       final Offset nextExtentOffset =
           Offset(extentRect.left + increment, extentRect.top);
-      final TextPosition nextExtent = nextExtentOffset.dx + position.pixels <= 0
+      nextExtent = nextExtentOffset.dx + position.pixels <= 0
           ? const TextPosition(offset: 0)
           : renderEditable.getPositionForPoint(
               renderEditable.localToGlobal(nextExtentOffset),
             );
-      nextSelection = _value.selection.copyWith(
-        extentOffset: nextExtent.offset,
-      );
     }
 
+    final bool collapseSelection =
+        intent.collapseSelection || !widget.selectionEnabled;
+    final TextSelection nextSelection = collapseSelection
+        ? TextSelection.fromPosition(nextExtent)
+        : _value.selection.copyWith(
+            extentOffset: nextExtent.offset,
+            affinity: nextExtent.affinity,
+          );
     bringIntoView(nextSelection.extent);
     userUpdateTextEditingValue(
       _value.copyWith(selection: nextSelection),
@@ -3474,9 +3475,6 @@ class MongolEditableTextState extends State<MongolEditableText>
       false,
       _characterBoundary,
     )),
-    ExtendSelectionByPageIntent: _makeOverridable(
-        CallbackAction<ExtendSelectionByPageIntent>(
-            onInvoke: _extendSelectionByPage)),
     MongolExtendSelectionByCharacterIntent: _makeOverridable(
         _UpdateTextSelectionAction<ExtendSelectionByCharacterIntent>(
       this,
@@ -3508,6 +3506,11 @@ class MongolEditableTextState extends State<MongolEditableText>
         _makeOverridable(_adjacentLineAction),
     MongolExtendSelectionHorizontallyToAdjacentLineIntent:
         _makeOverridable(_adjacentLineAction),
+    MongolExtendSelectionHorizontallyToAdjacentPageIntent: _makeOverridable(
+      CallbackAction<MongolExtendSelectionHorizontallyToAdjacentPageIntent>(
+        onInvoke: _extendSelectionHorizontallyByPage,
+      ),
+    ),
     ExtendSelectionToDocumentBoundaryIntent: _makeOverridable(
         _UpdateTextSelectionAction<ExtendSelectionToDocumentBoundaryIntent>(
             this, true, _documentBoundary)),

--- a/lib/src/editing/mongol_text_editing_intents.dart
+++ b/lib/src/editing/mongol_text_editing_intents.dart
@@ -26,6 +26,18 @@ class MongolExtendSelectionHorizontallyToAdjacentLineIntent
       {required super.forward, required super.collapseSelection});
 }
 
+/// Extends, or moves the current selection from the current
+/// [TextSelection.extent] position to the closest position on the adjacent
+/// horizontal page.
+class MongolExtendSelectionHorizontallyToAdjacentPageIntent
+    extends ExtendSelectionVerticallyToAdjacentPageIntent {
+  /// Creates a [MongolExtendSelectionHorizontallyToAdjacentPageIntent].
+  const MongolExtendSelectionHorizontallyToAdjacentPageIntent({
+    required super.forward,
+    required super.collapseSelection,
+  });
+}
+
 /// Expands the current selection to the closest line break in the direction
 /// given by [forward].
 ///

--- a/lib/src/editing/mongol_text_editing_shortcuts.dart
+++ b/lib/src/editing/mongol_text_editing_shortcuts.dart
@@ -26,10 +26,53 @@ class MongolTextEditingShortcuts extends StatelessWidget {
 
   final Widget? child;
 
+  static final Map<ShortcutActivator, Intent> _selectionPageShortcuts =
+      <ShortcutActivator, Intent>{
+    const SingleActivator(LogicalKeyboardKey.pageUp, shift: true):
+        const MongolExtendSelectionHorizontallyToAdjacentPageIntent(
+      forward: false,
+      collapseSelection: false,
+    ),
+    const SingleActivator(LogicalKeyboardKey.pageDown, shift: true):
+        const MongolExtendSelectionHorizontallyToAdjacentPageIntent(
+      forward: true,
+      collapseSelection: false,
+    ),
+  };
+
+  static final Map<ShortcutActivator, Intent> _commonPageShortcuts =
+      <ShortcutActivator, Intent>{
+    const SingleActivator(LogicalKeyboardKey.pageUp):
+        const MongolExtendSelectionHorizontallyToAdjacentPageIntent(
+      forward: false,
+      collapseSelection: true,
+    ),
+    const SingleActivator(LogicalKeyboardKey.pageDown):
+        const MongolExtendSelectionHorizontallyToAdjacentPageIntent(
+      forward: true,
+      collapseSelection: true,
+    ),
+    ..._selectionPageShortcuts,
+  };
+
+  static final Map<ShortcutActivator, Intent> _macPageShortcuts =
+      <ShortcutActivator, Intent>{
+    const SingleActivator(LogicalKeyboardKey.pageUp): const ScrollIntent(
+      direction: AxisDirection.left,
+      type: ScrollIncrementType.page,
+    ),
+    const SingleActivator(LogicalKeyboardKey.pageDown): const ScrollIntent(
+      direction: AxisDirection.right,
+      type: ScrollIncrementType.page,
+    ),
+    ..._selectionPageShortcuts,
+  };
+
   // These shortcuts are shared between most platforms except macOS, which
   // uses different modifier keys for the line/word modifier.
   static final Map<ShortcutActivator, Intent> _commonShortcuts =
       <ShortcutActivator, Intent>{
+    ..._commonPageShortcuts,
     // Arrow: Move Selection.
     const SingleActivator(LogicalKeyboardKey.arrowUp):
         const MongolExtendSelectionByCharacterIntent(
@@ -133,6 +176,7 @@ class MongolTextEditingShortcuts extends StatelessWidget {
   // platforms.
   static final Map<ShortcutActivator, Intent> _macShortcuts =
       <ShortcutActivator, Intent>{
+    ..._macPageShortcuts,
     const SingleActivator(LogicalKeyboardKey.arrowUp):
         const MongolExtendSelectionByCharacterIntent(
             forward: false, collapseSelection: true),


### PR DESCRIPTION
## Summary

This updates Mongol text editing for Flutter 3.44 and adds horizontal page
navigation for vertical text fields.

- Remove references to `ExtendSelectionByPageIntent`, which is no longer
  available in Flutter 3.44.
- Add an internal horizontal adjacent-page intent and action for Mongol text
  editing.
- Support horizontal Page Up and Page Down behavior using Flutter's
  `Shortcuts`, `Intent`, and `Action` architecture.
- Follow Flutter's platform conventions:
  - On macOS and iOS, Page Up and Page Down scroll one horizontal page without
    moving the caret.
  - On Android, Fuchsia, Linux, and Windows, Page Up and Page Down move the
    caret one horizontal page.
  - Shift + Page Up and Shift + Page Down extend the selection by one
    horizontal page on all platforms.

Fixes #60.
